### PR TITLE
 #15 コマンドラインオプションで size オプションが指定された場合の処理を追加する.

### DIFF
--- a/src/main/java/com/github/finder/Finder.java
+++ b/src/main/java/com/github/finder/Finder.java
@@ -27,7 +27,30 @@ public class Finder {
         if(args.getType() != null){
             flag &= checkTargetType(file, args.getType());
         }
+        if(args.getSize() != null){
+            flag &= checkTargetSize(file, args.getSize());
+        }
+
         return flag;
+    }
+    private boolean checkTargetSize(File file, String sizeString){
+        if(file.isFile()){
+            char sign = sizeString.charAt(0);
+            String string = sizeString.substring(1);
+            int size = Integer.parseInt(string);
+
+            switch(sign){
+            case '>':
+                return file.length() > size;
+            case '<':
+                return file.length() < size;
+            case '=':
+                return file.length() == size;
+            default:
+                // ignore
+            }
+        }
+        return false;
     }
     
     private boolean checkTargetType(File file, String type){


### PR DESCRIPTION
size オプションは与えられた文字列の最初の文字で，等しい，より大きい，より小さいを区別する．
例えば，-size '>100'のように指定された場合，サイズが100バイトより大きなファイルを見つけ出すものとする．
1文字目を抜き出すには，String 型のメソッド charAt(0) を利用する．
また，２文字目以降を取り出すには，String 型のメソッド substring(1) を利用する.
なお，検査対象がディレクトリの場合は，無視するものとする．
