### PR TITLE
 #17 コマンドラインオプションで grep オプションが指定された場合の処理を追加する.

### DIFF
--- a/src/main/java/com/github/finder/.#Finder.java
+++ b/src/main/java/com/github/finder/.#Finder.java
@@ -1,0 +1,1 @@
+takagikei@takagitoshi-no-MacBook-Air.local.4396


### PR DESCRIPTION
grepオプションは，ファイルの中身を検索し，指定された文字列が含まれたファイルであれば結果に含めるものとする．
ファイルはテキストファイルであると決め打ちで読むこととする．
検査対象がディレクトリの場合は，常に false を返す．
